### PR TITLE
docs: reframe project as Ugoos S905X5 (AM9 Pro / SK4 / SK4 Pro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-# Ugoos AM9 Pro research & tooling
+# Ugoos S905X5 research & tooling — AM9 Pro / SK4 / SK4 Pro
 
-This repo contains two related pieces of tooling for the Ugoos AM9 Pro (Amlogic S6 / S905X5):
+This repo contains two related pieces of tooling for Ugoos boxes built on the Amlogic S905X5 family:
 
-1. **CoreELEC eMMC installer** (`ce-emmc-install.sh` / `ce-emmc-restore.sh`) — installs CoreELEC to internal eMMC while `ceemmc` does not yet support this board, with a parallel restore script back to stock Android
-2. **A native Linux/macOS Amlogic burner** (`burn/aml-dnl-burn.py` + the `lib/aml_dnl_*` library trio) — a port of the relevant subset of the Windows-only Amlogic USB Burning Tool, sufficient to OTA-flash and full-restore the AM9 Pro from a `.img` file without booting Windows. Required only when restoring stock Android over the USB-C OTG port; the eMMC installer itself runs entirely on the device.
+| Device | SoC | CoreELEC board ID |
+|--------|-----|-------------------|
+| Ugoos AM9 Pro | S905X5-J (S6) | `s6_s905x5_ugoos_am9_pro` |
+| Ugoos SK4 | S905X5M-J (S7D) | `s7d_s905x5m_ugoos_sk4` |
+| Ugoos SK4 Pro | S905X5M-J (S7D) | `s7d_s905x5m_ugoos_sk4` (same DTB as the SK4) |
+
+1. **CoreELEC eMMC installer** (`ce-emmc-install.sh` / `ce-emmc-restore.sh`) — installs CoreELEC to internal eMMC while `ceemmc` does not yet support these boards, with a parallel restore script back to stock Android. **Tested on all three devices above.**
+2. **A native Linux/macOS Amlogic burner** (`burn/aml-dnl-burn.py` + the `lib/aml_dnl_*` library trio) — a port of the relevant subset of the Windows-only Amlogic USB Burning Tool, sufficient to OTA-flash and full-restore from a factory `.img` without booting Windows. Required only when restoring stock Android over the USB-C OTG port; the eMMC installer itself runs entirely on the device. **Exercised on AM9 Pro only** — see [Scope of testing](#scope-of-testing).
+
+The installer gates on the active DTB, so it accepts exactly the boards listed above. Adding another Ugoos S905X5 board with the same Amlogic partition layout is a one-line change to `SUPPORTED_BOARDS` in `ce-emmc-install.sh`.
 
 ---
 
@@ -11,7 +19,7 @@ This repo contains two related pieces of tooling for the Ugoos AM9 Pro (Amlogic 
 
 **This installation method is not supported by CoreELEC. Any support request, bug report, or forum post related to a CoreELEC install performed this way will be rejected, closed, or removed by the CoreELEC team. Do not ask for help on the CoreELEC forums if something goes wrong.**
 
-**Tested on one physical Ugoos AM9 Pro across CoreELEC nightlies from `22.0-Piers_nightly_20260514` through `22.0-Piers_nightly_20260527`, including survival across the auto-update path (see the cfgload-vs-mount-storage.sh discussion in the technical notes). A different hardware revision or a future firmware build may behave differently — the installer could fail or produce a non-booting eMMC, particularly if CoreELEC changes the cfgload script format the rebuild step depends on or restructures the `mount_storage` init function in a way that bypasses `/flash/mount-storage.sh`. The device cannot be permanently bricked from a software install: `boot0`/`boot1` are hardware write-protected, and the Amlogic USB Burning Tool (or the bundled `aml-dnl-burn.py`) can always restore stock Android over the USB-C OTG port. Per-device identity is preserved across the install too — the installer does not touch the `reserved` partition (p1) where the ETH MAC and serial are stored, and the WLAN/BT MAC lives in the Wi-Fi chip's OTP entirely independent of the eMMC. A bad install means an SD-card recovery cycle, not a dead device. See [`factory-investigation.md`](research/factory-investigation.md) and the [Per-Device Identity Provenance](research/emmc-research.md#per-device-identity-provenance) section in the research notes for the verified analysis.**
+**Tested on physical Ugoos AM9 Pro, SK4, and SK4 Pro hardware (see [Scope of testing](#scope-of-testing) for exactly what was verified where). A different hardware revision or a future firmware build may behave differently — the installer could fail or produce a non-booting eMMC, particularly if CoreELEC changes the cfgload script format the rebuild step depends on or restructures the `mount_storage` init function in a way that bypasses `/flash/mount-storage.sh`. The device cannot be permanently bricked from a software install: `boot0`/`boot1` are hardware write-protected, and the Amlogic USB Burning Tool can always restore stock Android over the USB-C OTG port. Per-device identity is preserved across the install too — the installer does not touch the `reserved` partition (p1) where the ETH MAC and serial are stored, and the WLAN/BT MAC lives in the Wi-Fi chip's OTP entirely independent of the eMMC. A bad install means an SD-card recovery cycle, not a dead device. See [`factory-investigation.md`](research/factory-investigation.md) and the [Per-Device Identity Provenance](research/emmc-research.md#per-device-identity-provenance) section in the research notes for the verified analysis.**
 
 **This process removes Android userdata and the rsv partition. Android can be restored — see [Restoring Android](#restoring-android) below.**
 
@@ -22,35 +30,58 @@ Specifically:
 - **Future firmware may prevent booting entirely.** This method bypasses normal eMMC install tooling. There is no guarantee it will work with any build other than the one it was tested on.
 - **No CoreELEC support.** This is explicitly unsupported. Do not file issues or ask for help on CoreELEC forums or Discord.
 
-If you are not comfortable with all of the above, run CoreELEC from the SD card instead.
+If you are not comfortable with all of the above, run CoreELEC from the SD card / USB stick instead.
 
 ---
 
 ## Background
 
-The Ugoos AM9 Pro runs an Amlogic S905X5 (S6) SoC. CoreELEC supports the hardware and includes the correct DTB (`s6_s905x5_ugoos_am9_pro.dtb`), but as of the May 2026 nightly the automated `ceemmc` install tool does not list this board as supported.
+The Ugoos AM9 Pro runs an Amlogic S905X5 (S6); the SK4 and SK4 Pro run the S905X5M (S7D). CoreELEC supports all three and ships the correct DTBs (`s6_s905x5_ugoos_am9_pro.dtb`, and `s7d_s905x5m_ugoos_sk4.dtb` for both SK4 variants), but the automated `ceemmc` install tool does not list any of these boards as supported.
 
-These scripts document what was done to get a working eMMC install on one specific unit. They are published as a technical reference, not a recommendation.
+They share the same Amlogic 29-partition Android layout, which is why one installer covers all three: `super` at p27, `rsv` at p28, `userdata` at p29, with the keystore in `reserved` (p1) and the U-Boot env at p2.
+
+These scripts document what was done to get a working eMMC install on specific units. They are published as a technical reference, not a recommendation.
 
 See [`emmc-research.md`](research/emmc-research.md) for the full research notes.
 
 ---
 
+## Scope of testing
+
+Not every part of this repo has been exercised on every device. What was verified where:
+
+| Component | AM9 Pro | SK4 | SK4 Pro |
+|-----------|---------|-----|---------|
+| `ce-emmc-install.sh` — install to eMMC | ✅ | ✅ | ✅ |
+| `ce-emmc-restore.sh` — restore Android layout | ✅ | ✅ | ✅ |
+| Survival across CoreELEC nightly auto-updates | ✅ | ✅ | ✅ |
+| `burn/` — USB DNL burner + in-device eMMC flasher | ✅ | ❌ untested | ❌ untested |
+| `img-tools/` — keystore / bootloader / logo / img parsing | ✅ | partial¹ | partial¹ |
+| `research/` — protocol captures, factory image analysis | ✅ | ❌ not repeated | ❌ not repeated |
+
+¹ `aml-keystore-tool.py` is used by the installer's identity cross-check on every board, so it is exercised on all three. The logo, bootloader, and `AML_PACK_v2` image tooling was only ever pointed at AM9 Pro artifacts.
+
+AM9 Pro coverage spans CoreELEC nightlies `22.0-Piers_nightly_20260514` through `22.0-Piers_nightly_20260527`, including survival across the auto-update path (see the cfgload-vs-`mount-storage.sh` discussion in the technical notes). SK4 and SK4 Pro were verified against the nightlies current at the time of their installs.
+
+The `burn/` and `research/` work is AM9 Pro-specific because it was built from a USB capture of the Windows burner flashing `AM9PRO_2.1.0.img` and from that image's contents. The DNL protocol itself is SoC-generic and the S905X5M should speak it identically, but nothing in `burn/` has been pointed at an SK4 or a Ugoos SK4 factory image. **Do not assume a full-restore flow that works on AM9 Pro will work on an SK4** — verify with `dry-run` first.
+
+---
+
 ## Requirements
 
-- Ugoos AM9 Pro booted into CoreELEC from an SD card
-- CoreELEC nightly build (tested on `22.0-Piers_nightly_20260514` and `22.0-Piers_nightly_20260525`)
+- A Ugoos AM9 Pro, SK4, or SK4 Pro booted into CoreELEC from removable media (SD card or USB stick — anywhere except the eMMC being repartitioned)
+- CoreELEC nightly build (AM9 Pro tested on `22.0-Piers_nightly_20260514` through `22.0-Piers_nightly_20260527`)
 - SSH access or direct terminal access to the device
 
 ---
 
 ## What the installer does
 
-1. Verifies you're on the right board and booting from SD, and that the eMMC still has the expected Android layout — partition **names** (`super`/`rsv`/`userdata`) are checked, not just numbers, so a partially-completed previous run is caught here instead of poisoning the backups below
+1. Verifies you're on a supported board (md5-matching the active `/flash/dtb.img` against the DTB list in `SUPPORTED_BOARDS`) and booting from removable media, and that the eMMC still has the expected Android layout — partition **names** (`super`/`rsv`/`userdata`) are checked, not just numbers, so a partially-completed previous run is caught here instead of poisoning the backups below
 2. Reads actual partition sizes from the live GPT for the confirmation screen
 3. Checks whether `rsv` (p28) contains data and notes it in the confirmation
 4. **Cross-checks device identity** — confirms the running `androidboot.serialno` and `mac=` on the kernel cmdline agree with the AMLNORMAL keystore values stored in `reserved` (p1). Aborts if they disagree (would indicate tampering or partial-flash state)
-5. Backs up to `/storage/emmc-backup` (on the SD card — the installer refuses to run if that directory already exists non-empty, so a rerun can never clobber a previous backup set):
+5. Backs up to `/storage/emmc-backup` (on the boot media — the installer refuses to run if that directory already exists non-empty, so a rerun can never clobber a previous backup set):
    - `partition_layout.txt` — the full partition table, needed by the restore script
    - `gpt_primary.bin` / `gpt_secondary.bin` — the raw GPT tables (the parted text dump captures geometry and names; the raw tables also preserve type GUIDs, unique GUIDs, and attribute flags for an exact restore if ever needed)
    - `rsv_backup.bin` — the rsv partition (64 MB)
@@ -60,7 +91,7 @@ See [`emmc-research.md`](research/emmc-research.md) for the full research notes.
    - `frp_backup.bin` — `frp` partition (p3, 2 MB) — contains 36 bytes of unit-unique anti-rollback / FRP signing material
    - `param_backup.bin` — `param` partition (p15, 16 MB) — ext4 filesystem with the TV picture-quality DB (`pq.db`, `TV_PICTURE`), likely tuned per-device at the factory
 
-   Every `dd` backup is size-verified against its partition (catches silent short reads), and the whole set is `sync`'d to the SD card before the first destructive operation.
+   Every `dd` backup is size-verified against its partition (catches silent short reads), and the whole set is `sync`'d to the boot media before the first destructive operation.
 6. **Keeps `super` (p27) untouched** — Android system images remain on the eMMC
 7. Deletes two Android partitions:
    - `rsv` (p28, ~64 MB) — reserved partition, unknown purpose, backed up first
@@ -68,7 +99,7 @@ See [`emmc-research.md`](research/emmc-research.md) for the full research notes.
 8. Creates two new partitions in their place:
    - `CE_FLASH` (p28, 512 MB, FAT32) — CoreELEC boot partition
    - `CE_STORAGE` (p29, ~53.9 GB, ext4) — CoreELEC storage
-9. Copies all boot files from the SD card's `/flash` to `CE_FLASH`
+9. Copies all boot files from the boot media's `/flash` to `CE_FLASH`
 10. Rebuilds `cfgload` to use `disk=LABEL=CE_STORAGE` instead of the dual-boot `disk=FOLDER=/dev/CE_STORAGE` path, with correct mkimage CRCs (see technical notes). Pass `--no-cfgload-rebuild` to skip this step.
 11. **Always installs `/flash/mount-storage.sh` + adds `nofsck` to `config.ini`** — these are the durable rescue layer. CoreELEC's nightly updater unconditionally overwrites `cfgload` from its stock source, reverting the step-10 patch on every update. `mount-storage.sh` is a first-class CE init hook (line ~635 of `/init` sources it instead of `mount_part`) that bypasses the broken `FOLDER=` mount path entirely; `nofsck` suppresses the retry loop the missing `/dev/CE_STORAGE` node would otherwise cause. Both files are user-added and never touched by the updater, so the device boots cleanly through every nightly update.
 12. With `--restore-logo PATH`: writes a custom boot logo to `p10` (the AML_RES container). PATH can be either a packed `.bin` (validated against the `AML_RES!` magic) or a directory of `NN_name.bmp` files produced by `aml-logo-tool.py unpack`.
@@ -100,7 +131,7 @@ bash /storage/ce-emmc-install.sh
 
 The script will walk you through confirmation prompts before making any changes. If `whiptail` is available and the terminal is large enough, it will use a simple TUI for the confirmation dialogs; otherwise it falls back to plain text. Either way, the destructive step requires typing `YES` — a single keypress is deliberately not enough to delete partitions.
 
-When it's done, remove the SD card and reboot — the device will boot CoreELEC from eMMC automatically.
+When it's done, remove the SD card / USB stick and reboot — the device will boot CoreELEC from eMMC automatically.
 
 ### After first eMMC boot
 
@@ -118,10 +149,10 @@ There are two restore paths depending on whether the backup files from the insta
 
 ### Option 1 — Restore script (recommended, no Windows PC required)
 
-If you have the backup files that `ce-emmc-install.sh` saved to the SD card's `/storage/emmc-backup` (older installer versions wrote them flat into `/storage` — the restore script finds either layout automatically), you can restore the original Android partition layout directly:
+If you have the backup files that `ce-emmc-install.sh` saved to the boot media's `/storage/emmc-backup` (older installer versions wrote them flat into `/storage` — the restore script finds either layout automatically), you can restore the original Android partition layout directly:
 
 ```bash
-# Boot CoreELEC from the SD card, then:
+# Boot CoreELEC from the SD card / USB stick, then:
 bash /storage/ce-emmc-restore.sh
 ```
 
@@ -163,26 +194,26 @@ Recovery options, in order of preference:
 
 ### Option 2 — Amlogic USB Burning Tool (backup files not available)
 
-The AM9 Pro can be fully restored to stock Android using the Amlogic USB Burning Tool. This works because `boot0` (the BL2 first-stage bootloader) is hardware write-protected and cannot be touched by anything running in Linux — the device can always enter USB burn mode.
+Any of these boxes can be fully restored to stock Android using the Amlogic USB Burning Tool. This works because `boot0` (the BL2 first-stage bootloader) is hardware write-protected and cannot be touched by anything running in Linux — the device can always enter USB burn mode.
 
 **What you need:**
 
 - A Windows PC
 - USB Burning Tool v3 (available from Ugoos)
-- The official factory firmware image (`AM9PRO_2.0.9.img` or newer)
+- The official factory firmware image **for your specific model** — `AM9PRO_2.0.9.img` or newer for the AM9 Pro, the corresponding SK4 / SK4 Pro image for those. These are not interchangeable; flashing the wrong model's image will produce a non-booting device.
 - A USB-C to USB-A cable
 
 **Process:**
 
 1. Power off the device
-2. Hold the recessed reset/ADB button while connecting the **USB-C OTG port** to the PC via USB-C to USB-A cable (the three USB-A ports are host-only and will not work)
+2. Hold the recessed reset/ADB button while connecting the **USB-C OTG port** to the PC via USB-C to USB-A cable (on the AM9 Pro, the three USB-A ports are host-only and will not work; check your model's port layout — the SK4 and SK4 Pro differ)
 3. The device will appear in USB Burning Tool in burn mode
 4. Load the factory `.img` file and click Start
 5. USB Burning Tool will wipe and rewrite every partition, fully restoring Android
 
-The official firmware image (`AM9PRO_2.0.9.img`) was fully parsed and confirmed to contain all required partitions: `super` (1507 MB, LP metadata + Android system images), `bootloader_a`, `boot_a`, `vendor_boot_a`, `dtbo_a`, `init_boot_a`, `logo`, `odm_ext_a`, and the SoC DTB. The image also includes the GPT table itself, so a full flash restores the original 29-partition Android layout exactly.
+The AM9 Pro factory image (`AM9PRO_2.0.9.img`) was fully parsed and confirmed to contain all required partitions: `super` (1507 MB, LP metadata + Android system images), `bootloader_a`, `boot_a`, `vendor_boot_a`, `dtbo_a`, `init_boot_a`, `logo`, `odm_ext_a`, and the SoC DTB. The image also includes the GPT table itself, so a full flash restores the original 29-partition Android layout exactly. The SK4 / SK4 Pro images were not parsed as part of this work, but they use the same `AML_PACK_v2` container — `img-tools/aml-img-tool.py` will inspect them.
 
-**Important:** The factory image restores Android to the state Ugoos shipped it — which includes **Magisk pre-installed** (root access). The device ships with an unlocked bootloader and Magisk patched into `init_boot_a`. The device is certified at Widevine L3 only (no L1 attestation path with an unlocked bootloader). Per-device identity is preserved across the burn because the factory image does not include the `reserved` partition (p1) where the ETH MAC and serial are stored — USB Burning Tool leaves p1 alone. The WLAN/BT MAC lives in the Broadcom chip's OTP and is entirely independent of the eMMC. See [`factory-investigation.md`](research/factory-investigation.md) for the underlying analysis.
+**Important:** The factory image restores Android to the state Ugoos shipped it — which for the AM9 Pro includes **Magisk pre-installed** (root access). That unit ships with an unlocked bootloader and Magisk patched into `init_boot_a`, and is certified at Widevine L3 only (no L1 attestation path with an unlocked bootloader). Whether the SK4 / SK4 Pro stock images ship the same way was not checked. Per-device identity is preserved across the burn because the factory image does not include the `reserved` partition (p1) where the ETH MAC and serial are stored — USB Burning Tool leaves p1 alone. The WLAN/BT MAC lives in the Wi-Fi chip's OTP and is entirely independent of the eMMC. See [`factory-investigation.md`](research/factory-investigation.md) for the underlying analysis.
 
 ---
 
@@ -198,7 +229,7 @@ The original install approach placed CE_FLASH at p27 (replacing `super`). The cu
 
 `cfgload` is a compiled U-Boot script in mkimage format with two CRC32 fields in its header (one over the header itself, one over the data). Editing it with a text editor or `sed` changes the content but leaves the old CRCs in place — U-Boot verifies them on load and silently rejects the script, failing without any obvious error.
 
-The installer reads the stock cfgload from the SD card, performs the `FOLDER=/dev/CE_STORAGE` → `LABEL=CE_STORAGE` substitution in the inner script body, then rebuilds the mkimage container with correct CRCs. It does this in Python because `mkimage` is not installed on CoreELEC — the legacy-script format is straightforward to pack with `struct` and `zlib.crc32`. The result is byte-identical (modulo timestamp and header CRC) to what `mkimage -A arm64 -T script -O linux -C none -d <script> <out>` produces. The same packing logic is exposed as a standalone utility in [`scripts/make-cfgload.py`](scripts/make-cfgload.py).
+The installer reads the stock cfgload from the boot media, performs the `FOLDER=/dev/CE_STORAGE` → `LABEL=CE_STORAGE` substitution in the inner script body, then rebuilds the mkimage container with correct CRCs. It does this in Python because `mkimage` is not installed on CoreELEC — the legacy-script format is straightforward to pack with `struct` and `zlib.crc32`. The result is byte-identical (modulo timestamp and header CRC) to what `mkimage -A arm64 -T script -O linux -C none -d <script> <out>` produces. The same packing logic is exposed as a standalone utility in [`scripts/make-cfgload.py`](scripts/make-cfgload.py).
 
 The rebuild step is idempotent: running it on an already-patched cfgload is a no-op.
 
@@ -229,14 +260,14 @@ Low but non-zero. `boot0`/`boot1` are hardware write-protected — the SoC's fir
 
 | File | Description |
 |------|-------------|
-| `ce-emmc-install.sh` | CoreELEC eMMC installer |
-| `ce-emmc-restore.sh` | Android partition restore script |
+| `ce-emmc-install.sh` | CoreELEC eMMC installer. Board-gated on `SUPPORTED_BOARDS` — AM9 Pro, SK4, SK4 Pro. |
+| `ce-emmc-restore.sh` | Android partition restore script. Board-agnostic — it reconstructs the layout from the installer's backup set, so it works on any board the installer ran on. |
 
 ### Root files
 
 | File | Description |
 |------|-------------|
-| `am9pro-usb-restore.sh` | Bash wrapper that verifies a `.img`, sanity-checks the closed-source `adnl` binary if present, and (when device is in burn mode) confirms it identifies cleanly. Predates the native burner — kept for the closed-source verification path. **Read-only.** |
+| `am9pro-usb-restore.sh` | Bash wrapper that verifies a `.img`, sanity-checks the closed-source `adnl` binary if present, and (when device is in burn mode) confirms it identifies cleanly. Predates the native burner — kept for the closed-source verification path. Named for the AM9 Pro because that is the only model it has been run against. **Read-only.** |
 
 ### Subdirectories
 

--- a/am9pro-usb-restore.sh
+++ b/am9pro-usb-restore.sh
@@ -8,6 +8,13 @@
 # only verifies that the pieces fit together — it does NOT flash anything.
 # Phase 2 (--unsafe-flash, the actual restore flow) is not yet built.
 #
+# Scope: the CoreELEC eMMC installer in this repo is tested on AM9 Pro,
+# SK4, and SK4 Pro, but this USB restore path has only been exercised
+# against AM9 Pro factory images on AM9 Pro hardware. The DNL protocol is
+# SoC-generic, so it should work with an SK4/SK4 Pro factory .img, but
+# that is untested — and the burn-mode button/port steps below are the
+# AM9 Pro's physical layout. Check your model's before following them.
+#
 # Usage:
 #   am9pro-usb-restore.sh <image.img> [options]
 #

--- a/burn/README.md
+++ b/burn/README.md
@@ -1,12 +1,23 @@
 # burn/ — active flashers
 
+> **Scope: AM9 Pro only.** The CoreELEC eMMC installer at the repo root is tested
+> on AM9 Pro, SK4, and SK4 Pro, but everything in this directory was built and
+> exercised against AM9 Pro hardware and `AM9PRO_*.img` factory images. The
+> ADNL/DNL protocol is SoC-generic and the S905X5M in the SK4 / SK4 Pro should
+> speak it identically, but that is inference, not a test result. If you point
+> these at an SK4, start with `aml-dnl-status.py` and `dry-run`, and treat a
+> `full-restore` as unverified.
+
 | Tool | Where it runs | What it does |
 |------|--------------|--------------|
-| [`aml-dnl-burn.py`](aml-dnl-burn.py) | Host (Linux/macOS, device in DNL/burn mode over USB-C OTG) | The native Amlogic burner — replaces the Windows-only USB Burning Tool for the AM9 Pro. Subcommands: `dry-run`, `ota-keep-ce` (update Android slot _a, preserve CE_FLASH/CE_STORAGE), `full-restore`. Destructive ops gated by `--yes-i-mean-it`. |
+| [`aml-dnl-burn.py`](aml-dnl-burn.py) | Host (Linux/macOS, device in DNL/burn mode over USB-C OTG) | The native Amlogic burner — replaces the Windows-only USB Burning Tool. Subcommands: `dry-run`, `ota-keep-ce` (update Android slot _a, preserve CE_FLASH/CE_STORAGE), `full-restore`. Destructive ops gated by `--yes-i-mean-it`. |
 | [`aml-dnl-status.py`](aml-dnl-status.py) | Host (device in DNL mode) | Read-only DNL probe: identifies device, dumps chipinfo pages, prints stage/mode. Safe to run any time the device is in burn mode. |
-| [`aml-emmc-burn.py`](aml-emmc-burn.py) | On the AM9 Pro under CoreELEC | In-device eMMC flasher. Parses an AML `.img` and writes Android-side partitions directly to `/dev/mmcblk0pN`, bypassing USB. CE_FLASH/CE_STORAGE and the GPT are never touched. Modes: `--list`, `--verify-only`, `--dry-run`, `--ota` (full Android-side flash + reboot in one shot). Use case: "install a Ugoos OTA from CoreELEC without leaving CE." |
+| [`aml-emmc-burn.py`](aml-emmc-burn.py) | On the device under CoreELEC | In-device eMMC flasher. Parses an AML `.img` and writes Android-side partitions directly to `/dev/mmcblk0pN`, bypassing USB. CE_FLASH/CE_STORAGE and the GPT are never touched. Modes: `--list`, `--verify-only`, `--dry-run`, `--ota` (full Android-side flash + reboot in one shot). Use case: "install a Ugoos OTA from CoreELEC without leaving CE." |
 
 All three import the shared libraries (`aml_dnl_proto`, `aml_dnl_ops`, `aml_dnl_flows`, `aml_img`) from `../lib/` via a `sys.path` adjustment.
+
+Factory images are per-model and not interchangeable — flash only the `.img`
+that matches the box in front of you.
 
 ## Quick reference
 

--- a/ce-emmc-install.sh
+++ b/ce-emmc-install.sh
@@ -2,9 +2,9 @@
 # ce-emmc-install.sh — CoreELEC eMMC installer for Ugoos S905X5 boxes
 #
 # Workaround until ceemmc adds support for Ugoos S905X5 boards.
-# Originally written for Ugoos AM9 Pro (s6_s905x5_ugoos_am9_pro); the
-# Ugoos SK4 (s7d_s905x5m_ugoos_sk4) is also accepted because it ships the
-# same Amlogic partition layout. Add new boards to SUPPORTED_BOARDS below.
+# Tested on Ugoos AM9 Pro (s6_s905x5_ugoos_am9_pro) and on the Ugoos SK4
+# and SK4 Pro, which both boot s7d_s905x5m_ugoos_sk4 and ship the same
+# Amlogic partition layout. Add new boards to SUPPORTED_BOARDS below.
 #
 # Must be run from CoreELEC booted off removable media (SD card or USB
 # stick) — anywhere except the eMMC itself, which we're about to repartition.
@@ -114,7 +114,7 @@ FLASH_DIR="/flash"
 # partition layout, drop another line here.
 SUPPORTED_BOARDS=(
     "s6_s905x5_ugoos_am9_pro.dtb|Ugoos AM9 Pro"
-    "s7d_s905x5m_ugoos_sk4.dtb|Ugoos SK4"
+    "s7d_s905x5m_ugoos_sk4.dtb|Ugoos SK4 / SK4 Pro"
 )
 MNT_FLASH="/var/ce_flash"
 MNT_STORAGE="/var/ce_storage"

--- a/research/README.md
+++ b/research/README.md
@@ -4,6 +4,18 @@ The investigative writeups and frozen evidence files that the tooling in
 the rest of the repo was built from. Kept alongside the code so the
 "why" behind each design decision stays discoverable.
 
+> **Scope: this is AM9 Pro evidence.** Every measurement, dump, hex offset,
+> partition map, and USB capture in this directory was taken from one physical
+> Ugoos AM9 Pro (`s6_s905x5_ugoos_am9_pro`). The eMMC installer built on top of
+> it is separately tested on the SK4 and SK4 Pro (`s7d_s905x5m_ugoos_sk4`), and
+> the structural conclusions that installer depends on — the 29-partition layout
+> with `super`/`rsv`/`userdata` at p27/p28/p29, the AMLNORMAL keystore in
+> `reserved` (p1), the U-Boot env at p2 — hold on those boards too, because the
+> installer verifies them at runtime and refuses to proceed otherwise. Nothing
+> else here was re-derived on S905X5M silicon. Treat byte offsets, chip IDs,
+> partition sizes, and factory-image contents as AM9 Pro figures unless a
+> document says otherwise.
+
 | File | What's in it |
 |------|--------------|
 | [`emmc-research.md`](emmc-research.md) | Main research notes — eMMC hardware, partition layout, encryption, identity provenance, U-Boot env, the manual install method, the CE auto-update interaction with cfgload, USB burn-mode protocol findings. The reference document for the project. |

--- a/research/emmc-research.md
+++ b/research/emmc-research.md
@@ -9,6 +9,18 @@
 **CoreELEC:** 22.0-Piers_nightly_20260514  
 **Kernel:** 5.15.196  
 
+> **Applicability.** This is a single-device record: every figure below was
+> measured on the AM9 Pro described in this header. The installer these notes
+> produced (`ce-emmc-install.sh`) is now also tested on the Ugoos SK4 and SK4
+> Pro, which run S905X5M (S7D) silicon under `s7d_s905x5m_ugoos_sk4`. Those
+> boards share the Amlogic 29-partition Android layout this document maps —
+> `super`/`rsv`/`userdata` at p27/p28/p29, AMLNORMAL keystore in `reserved`
+> (p1), U-Boot env at p2 — which is why one installer covers all three, and the
+> installer re-verifies that layout by partition name at runtime rather than
+> trusting it. Everything else here (SoC/CPU/GPU identification, eMMC chip
+> details, exact partition sizes, byte offsets, factory image contents, the
+> DNL/USB findings) is AM9 Pro-specific and was not re-derived on the SK4.
+
 ---
 
 ## Claims Provenance — Device Truth vs CoreELEC Observation


### PR DESCRIPTION
The eMMC installer is tested on AM9 Pro, SK4, and SK4 Pro. SK4 and SK4 Pro both boot s7d_s905x5m_ugoos_sk4, so they share one SUPPORTED_BOARDS entry rather than needing a new row.

- ce-emmc-install.sh: name the shared SK4 entry "Ugoos SK4 / SK4 Pro" so the confirmation screen and --info identify the family correctly; header comment now states tested-on rather than "written for AM9 Pro, SK4 also accepted"
- README: retitle, add device/SoC/board-ID table, explain why one installer covers all three (shared 29-partition Amlogic layout), and add a "Scope of testing" section
- Scope the AM9 Pro-only work explicitly: burn/, probes/, and research/ were built from a USB capture of the Windows burner flashing AM9PRO_2.1.0.img and from that image's contents, and were not re-derived on S905X5M silicon. Factory images are per-model and not interchangeable.
- Correct "booted from an SD card" to "removable media (SD card or USB stick)" throughout; the scripts have accepted USB boot since 8e022b4 but the docs never caught up.